### PR TITLE
Enforce presence of deployer prefix in deployment salts

### DIFF
--- a/script/Base.s.sol
+++ b/script/Base.s.sol
@@ -148,6 +148,11 @@ abstract contract BaseScript is Script {
         bytes1 crosschainProtectionFlag = isCrosschainProtected ? bytes1(0x01) : bytes1(0x00);
         bytes32 nameEntropyHash = keccak256(abi.encodePacked(nameEntropy));
         bytes11 nameEntropyHash11 = bytes11(nameEntropyHash);
+        // A zero deployer would make salt[0:20] == address(0), which CreateX treats as the permissionless,
+        // squattable salt form (anyone could front-run the deployment address) instead of the deployer-protected
+        // form. CreateX enforces the deployer == msg.sender match on-chain and reverts on any nonzero mismatch.
+        require(deployer != address(0), "makeSalt: salt not deployer-prefixed");
+
         return bytes32(abi.encodePacked(deployer, crosschainProtectionFlag, nameEntropyHash11));
     }
 

--- a/script/deploy/DeployBoringVaultAndManager.s.sol
+++ b/script/deploy/DeployBoringVaultAndManager.s.sol
@@ -51,12 +51,6 @@ contract DeployBoringVaultAndManager is BaseScript {
         bytes32 SALT_PAXG_USD_RATE_PROVIDER =
             makeSalt(broadcaster, false, "PaxgyFundsAutomationVault: PaxgUsdRateProvider");
 
-        require(address(bytes20(SALT_ROLES_AUTHORITY)) == broadcaster, "salt not deployer-prefixed");
-        require(address(bytes20(SALT_BORING_VAULT)) == broadcaster, "salt not deployer-prefixed");
-        require(address(bytes20(SALT_MANAGER_WITH_MERKLE_VERIFICATION)) == broadcaster, "salt not deployer-prefixed");
-        require(address(bytes20(SALT_EQUIVALENT_EXCHANGE_UMANAGER)) == broadcaster, "salt not deployer-prefixed");
-        require(address(bytes20(SALT_PAXG_USD_RATE_PROVIDER)) == broadcaster, "salt not deployer-prefixed");
-
         // deploy a roles authority
         RolesAuthority rolesAuthority = RolesAuthority(
             CREATEX.deployCreate3(


### PR DESCRIPTION
This replaces the PAXGy funds automation vault deployer prefix checks with a single global check, made within the `makeSalt` function.

Based on the EE UManager branch because it improves a fix made there.  Don't merge until that branch is merged and this PR's base is updated.